### PR TITLE
Added support / tests for custom _id types

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,16 +6,20 @@ Object.defineProperty(exports, "__esModule", {
 exports.RollbackError = undefined;
 
 exports.default = function (schema, opts) {
-  var options = (0, _lodash.merge)({}, defaultOptions, opts);
+  var options = (0, _lodash.merge)({}, defaultOptions, opts
+
+  // get _id type from schema
+  );options._idType = schema.tree._id.type;
 
   // validate parameters
   (0, _assert2.default)(options.mongoose, '`mongoose` option must be defined');
   (0, _assert2.default)(options.name, '`name` option must be defined');
   (0, _assert2.default)(!schema.methods.data, 'conflicting instance method: `data`');
+  (0, _assert2.default)(options._idType, 'schema is missing an `_id` property'
 
   // used to compare instance data snapshots. depopulates instance,
   // removes version key and object id
-  schema.methods.data = function () {
+  );schema.methods.data = function () {
     return this.toObject({
       depopulate: true,
       versionKey: false,
@@ -44,11 +48,11 @@ exports.default = function (schema, opts) {
         // get all patches that should be applied
         var apply = (0, _lodash.dropRightWhile)(patches, function (patch) {
           return patch.id !== patchId;
-        });
+        }
 
         // if the patches that are going to be applied are all existing patches,
         // the rollback attempts to rollback to the latest patch
-        if (patches.length === apply.length) {
+        );if (patches.length === apply.length) {
           return reject(new RollbackError('rollback to latest patch'));
         }
 
@@ -56,10 +60,10 @@ exports.default = function (schema, opts) {
         var state = {};
         apply.forEach(function (patch) {
           _fastJsonPatch2.default.apply(state, patch.ops, true);
-        });
+        }
 
         // save new state and resolve with the resulting document
-        _this.set((0, _lodash.merge)(data, state)).save().then(resolve).catch(reject);
+        );_this.set((0, _lodash.merge)(data, state)).save().then(resolve).catch(reject);
       });
     });
   };
@@ -70,19 +74,19 @@ exports.default = function (schema, opts) {
   schema.statics.Patches = Patches;
   schema.virtual('patches').get(function () {
     return Patches;
-  });
+  }
 
   // after a document is initialized or saved, fresh snapshots of the
   // documents data are created
-  var snapshot = function snapshot() {
+  );var snapshot = function snapshot() {
     this._original = toJSON(this.data());
   };
   schema.post('init', snapshot);
-  schema.post('save', snapshot);
+  schema.post('save', snapshot
 
   // when a document is removed and `removePatches` is not set to false ,
   // all patch documents from the associated patch collection are also removed
-  schema.pre('remove', function (next) {
+  );schema.pre('remove', function (next) {
     if (!options.removePatches) {
       return next();
     }
@@ -94,21 +98,21 @@ exports.default = function (schema, opts) {
         return patch.remove();
       }));
     }).then(next).catch(next);
-  });
+  }
 
   // when a document is saved, the json patch that reflects the changes is
   // computed. if the patch consists of one or more operations (meaning the
   // document has changed), a new patch document reflecting the changes is
   // added to the associated patch collection
-  schema.pre('save', function (next) {
+  );schema.pre('save', function (next) {
     var _this2 = this;
 
     var ref = this._id;
 
-    var ops = _fastJsonPatch2.default.compare(this.isNew ? {} : this._original, toJSON(this.data()));
+    var ops = _fastJsonPatch2.default.compare(this.isNew ? {} : this._original, toJSON(this.data())
 
     // don't save a patch when there are no changes to save
-    if (!ops.length) {
+    );if (!ops.length) {
       return next();
     }
 
@@ -154,7 +158,7 @@ var createPatchModel = function createPatchModel(options) {
   var def = {
     date: { type: Date, required: true, default: Date.now },
     ops: { type: [], required: true },
-    ref: { type: _mongoose.Schema.Types.ObjectId, required: true, index: true }
+    ref: { type: options._idType, required: true, index: true }
   };
 
   (0, _lodash.each)(options.includes, function (type, name) {
@@ -170,11 +174,10 @@ var defaultOptions = {
   includes: {},
   removePatches: true,
   transforms: [_humps.pascalize, _humps.decamelize]
-};
 
-// used to convert bson to json - especially ObjectID references need
-// to be converted to hex strings so that the jsonpatch `compare` method
-// works correctly
-var toJSON = function toJSON(obj) {
+  // used to convert bson to json - especially ObjectID references need
+  // to be converted to hex strings so that the jsonpatch `compare` method
+  // works correctly
+};var toJSON = function toJSON(obj) {
   return JSON.parse(JSON.stringify(obj));
 };

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ const createPatchModel = (options) => {
   const def = {
     date: { type: Date, required: true, default: Date.now },
     ops: { type: [], required: true },
-    ref: { type: Schema.Types.ObjectId, required: true, index: true }
+    ref: { type: options._idType, required: true, index: true }
   }
 
   each(options.includes, (type, name) => {
@@ -47,10 +47,14 @@ const toJSON = (obj) => JSON.parse(JSON.stringify(obj))
 export default function (schema, opts) {
   const options = merge({}, defaultOptions, opts)
 
+  // get _id type from schema
+  options._idType = schema.tree._id.type
+
   // validate parameters
   assert(options.mongoose, '`mongoose` option must be defined')
   assert(options.name, '`name` option must be defined')
   assert(!schema.methods.data, 'conflicting instance method: `data`')
+  assert(options._idType, 'schema is missing an `_id` property')
 
   // used to compare instance data snapshots. depopulates instance,
   // removes version key and object id


### PR DESCRIPTION
#7

I believe only `Strings`, `Numbers`, and `ObjectId` types can be used for the `_id` value before mongoose starts to have issues itself so the tests only cover those three.

Otherwise, pretty straight forward diff.