### PR TITLE
Support Mongoose .update and .findOneAndUpdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Post.create({ title: 'Included in every patch' })
 
 The value of the patch documents properties is read from the versioned documents property of the same name.
 
-##### Reading from virtuals
+#### Reading from virtuals
 There is an additional option that allows storing information in the patch documents that is not stored in the versioned documents. To do so, you can use a combination of [virtual type setters](http://mongoosejs.com/docs/guide.html#virtuals) on the versioned document and an additional `from` property in the include options of __mongoose-patch-history__:
 
 ```javascript
@@ -195,4 +195,13 @@ Post.create({ title: 'v1', user: mongoose.Types.ObjectId() })
         user: mongoose.Types.ObjectId()
       }))
   })
+```
+
+#### Reading from query options
+In situations where you are running Mongoose queries directly instead of via a document, you can specify the extra fields in the query options.
+
+Example:
+
+```javascript
+Post.findOneAndUpdate({ _id: '4edd40c86762e0fb12000012' }, { title: 'Why is hiring broken? (updated)' }, { _user: mongoose.Types.ObjectId() })
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,20 +6,20 @@ Object.defineProperty(exports, "__esModule", {
 exports.RollbackError = undefined;
 
 exports.default = function (schema, opts) {
-  var options = (0, _lodash.merge)({}, defaultOptions, opts
+  var options = (0, _lodash.merge)({}, defaultOptions, opts);
 
   // get _id type from schema
-  );options._idType = schema.tree._id.type;
+  options._idType = schema.tree._id.type;
 
   // validate parameters
   (0, _assert2.default)(options.mongoose, '`mongoose` option must be defined');
   (0, _assert2.default)(options.name, '`name` option must be defined');
   (0, _assert2.default)(!schema.methods.data, 'conflicting instance method: `data`');
-  (0, _assert2.default)(options._idType, 'schema is missing an `_id` property'
+  (0, _assert2.default)(options._idType, 'schema is missing an `_id` property');
 
   // used to compare instance data snapshots. depopulates instance,
   // removes version key and object id
-  );schema.methods.data = function () {
+  schema.methods.data = function () {
     return this.toObject({
       depopulate: true,
       versionKey: false,
@@ -48,22 +48,22 @@ exports.default = function (schema, opts) {
         // get all patches that should be applied
         var apply = (0, _lodash.dropRightWhile)(patches, function (patch) {
           return patch.id !== patchId;
-        }
+        });
 
         // if the patches that are going to be applied are all existing patches,
         // the rollback attempts to rollback to the latest patch
-        );if (patches.length === apply.length) {
+        if (patches.length === apply.length) {
           return reject(new RollbackError('rollback to latest patch'));
         }
 
         // apply patches to `state`
         var state = {};
         apply.forEach(function (patch) {
-          _fastJsonPatch2.default.apply(state, patch.ops, true);
-        }
+          _fastJsonPatch2.default.applyPatch(state, patch.ops, true);
+        });
 
         // save new state and resolve with the resulting document
-        );_this.set((0, _lodash.merge)(data, state)).save().then(resolve).catch(reject);
+        _this.set((0, _lodash.merge)(data, state)).save().then(resolve).catch(reject);
       });
     });
   };
@@ -74,55 +74,169 @@ exports.default = function (schema, opts) {
   schema.statics.Patches = Patches;
   schema.virtual('patches').get(function () {
     return Patches;
-  }
+  });
 
   // after a document is initialized or saved, fresh snapshots of the
   // documents data are created
-  );var snapshot = function snapshot() {
+  var snapshot = function snapshot() {
     this._original = toJSON(this.data());
   };
   schema.post('init', snapshot);
-  schema.post('save', snapshot
+  schema.post('save', snapshot);
 
   // when a document is removed and `removePatches` is not set to false ,
   // all patch documents from the associated patch collection are also removed
-  );schema.pre('remove', function (next) {
+  function deletePatches(document) {
+    var ref = document._id;
+
+    return document.patches.find({ ref: document._id }).then(function (patches) {
+      return (0, _bluebird.join)(patches.map(function (patch) {
+        return patch.remove();
+      }));
+    });
+  }
+
+  schema.pre('remove', function (next) {
     if (!options.removePatches) {
       return next();
     }
 
-    var ref = this._id;
-
-    this.patches.find({ ref: ref }).then(function (patches) {
-      return (0, _bluebird.join)(patches.map(function (patch) {
-        return patch.remove();
-      }));
-    }).then(next).catch(next);
-  }
+    deletePatches(this).then(function () {
+      return next();
+    }).catch(next);
+  });
 
   // when a document is saved, the json patch that reflects the changes is
   // computed. if the patch consists of one or more operations (meaning the
   // document has changed), a new patch document reflecting the changes is
   // added to the associated patch collection
-  );schema.pre('save', function (next) {
-    var _this2 = this;
+  function createPatch(document) {
+    var queryOptions = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var ref = document._id;
 
-    var ref = this._id;
-
-    var ops = _fastJsonPatch2.default.compare(this.isNew ? {} : this._original, toJSON(this.data())
+    var ops = _fastJsonPatch2.default.compare(document.isNew ? {} : document._original || {}, toJSON(document.data()));
 
     // don't save a patch when there are no changes to save
-    );if (!ops.length) {
-      return next();
+    if (!ops.length) {
+      return _bluebird2.default.resolve();
     }
 
     // assemble patch data
     var data = { ops: ops, ref: ref };
     (0, _lodash.each)(options.includes, function (type, name) {
-      data[name] = _this2[type.from || name];
+      data[name] = document[type.from || name] || queryOptions[type.from || name];
     });
 
-    this.patches.create(data).then(next).catch(next);
+    return document.patches.create(data);
+  }
+
+  schema.pre('save', function (next) {
+    createPatch(this).then(function () {
+      return next();
+    }).catch(next);
+  });
+
+  schema.pre('findOneAndRemove', function (next) {
+    if (!options.removePatches) {
+      return next();
+    }
+
+    deletePatches(this).then(function () {
+      return next();
+    }).catch(next);
+  });
+
+  schema.pre('findOneAndUpdate', preUpdateOne);
+
+  function preUpdateOne(next) {
+    var _this2 = this;
+
+    this.model.findOne(this._conditions).then(function (original) {
+      original = original || new _this2.model({});
+      _this2._original = toJSON(original.data());
+    }).then(function () {
+      return next();
+    }).catch(next);
+  }
+
+  schema.post('findOneAndUpdate', function (doc, next) {
+    if (!this.options.new) {
+      return postUpdateOne.call(this, {}, next);
+    }
+
+    doc._original = this._original;
+    createPatch(doc, this.options).then(function () {
+      return next();
+    }).catch(next);
+  });
+
+  function postUpdateOne(result, next) {
+    var _this3 = this;
+
+    if (result.nModified === 0) return;
+
+    var conditions = Object.assign({}, this._conditions, this._update.$set || this._update);
+
+    this.model.findOne(conditions).then(function (doc) {
+      doc._original = _this3._original;
+      return createPatch(doc, _this3.options);
+    }).then(function () {
+      return next();
+    }).catch(next);
+  }
+
+  schema.pre('updateOne', preUpdateOne);
+  schema.post('updateOne', postUpdateOne);
+
+  function preUpdateMany(next) {
+    var _this4 = this;
+
+    this.model.find(this._conditions).then(function () {
+      var originals = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
+
+      _this4._originals = [].concat(originals).map(function (original) {
+        return original || new _this4.model({});
+      }).map(function (original) {
+        return toJSON(original.data());
+      });
+    }).then(function () {
+      return next();
+    }).catch(next);
+  }
+
+  function postUpdateMany(result, next) {
+    var _this5 = this;
+
+    if (result.nModified === 0) return;
+
+    var conditions = Object.assign({}, this._conditions, this._update.$set || this._update);
+
+    this.model.find(conditions).then(function (docs) {
+      return _bluebird2.default.all(docs.map(function (doc, i) {
+        doc._original = _this5._originals[i];
+        return createPatch(doc, _this5.options);
+      }));
+    }).then(function () {
+      return next();
+    }).catch(next);
+  }
+
+  schema.pre('updateMany', preUpdateMany);
+  schema.post('updateMany', postUpdateMany);
+
+  schema.pre('update', function (next) {
+    if (this.options.multi) {
+      preUpdateMany.call(this, next);
+    } else {
+      preUpdateOne.call(this, next);
+    }
+  });
+  schema.post('update', function (result, next) {
+    if (this.options.many) {
+      postUpdateMany.call(this, result, next);
+    } else {
+      postUpdateOne.call(this, result, next);
+    }
   });
 };
 


### PR DESCRIPTION
* Added support for `findByIdAndUpdate`, `findOneAndUpdate`, `updateOne`, `updateMany`, and `update` queries
* Fix `jsonpatch.apply` deprecation warning
* Fixed `mongoose.connect` deprecation warning

Resolves #11