### PR TITLE
Fix handling of update operators other than $set

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -202,14 +202,37 @@ exports.default = function (schema, opts) {
   function preUpdateMany(next) {
     var _this4 = this;
 
-    this.model.find(this._conditions).then(function () {
-      var originals = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
+    this.model.find(this._conditions).then(function (originals) {
+      var originalIds = [];
+      var originalData = [];
+      var _iteratorNormalCompletion = true;
+      var _didIteratorError = false;
+      var _iteratorError = undefined;
 
-      _this4._originals = [].concat(originals).map(function (original) {
-        return original || new _this4.model({});
-      }).map(function (original) {
-        return toJSON(original.data());
-      });
+      try {
+        for (var _iterator = originals[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+          var original = _step.value;
+
+          originalIds.push(original._id);
+          originalData.push(toJSON(original.data()));
+        }
+      } catch (err) {
+        _didIteratorError = true;
+        _iteratorError = err;
+      } finally {
+        try {
+          if (!_iteratorNormalCompletion && _iterator.return) {
+            _iterator.return();
+          }
+        } finally {
+          if (_didIteratorError) {
+            throw _iteratorError;
+          }
+        }
+      }
+
+      _this4._originalIds = originalIds;
+      _this4._originals = originalData;
     }).then(function () {
       return next();
     }).catch(next);
@@ -220,7 +243,7 @@ exports.default = function (schema, opts) {
 
     if (result.nModified === 0) return;
 
-    var conditions = Object.assign({}, this._conditions, this._update.$set || this._update);
+    var conditions = { _id: { $in: this._originalIds } };
 
     this.model.find(conditions).then(function (docs) {
       return _bluebird2.default.all(docs.map(function (doc, i) {

--- a/src/index.js
+++ b/src/index.js
@@ -250,11 +250,8 @@ export default function(schema, opts) {
   function preUpdateMany(next) {
     this.model
       .find(this._conditions)
-      .then((originals = []) => {
-        this._originals = []
-          .concat(originals)
-          .map(original => original || new this.model({}))
-          .map(original => toJSON(original.data()))
+      .then(originals => {
+        this._originals = originals.map(original => toJSON(original.data()))
       })
       .then(() => next())
       .catch(next)

--- a/src/index.js
+++ b/src/index.js
@@ -251,7 +251,14 @@ export default function(schema, opts) {
     this.model
       .find(this._conditions)
       .then(originals => {
-        this._originals = originals.map(original => toJSON(original.data()))
+        const originalIds = []
+        const originalData = []
+        for (const original of originals) {
+          originalIds.push(original._id)
+          originalData.push(toJSON(original.data()))
+        }
+        this._originalIds = originalIds
+        this._originals = originalData
       })
       .then(() => next())
       .catch(next)
@@ -260,11 +267,7 @@ export default function(schema, opts) {
   function postUpdateMany(result, next) {
     if (result.nModified === 0) return
 
-    const conditions = Object.assign(
-      {},
-      this._conditions,
-      this._update.$set || this._update
-    )
+    const conditions = { _id: { $in: this._originalIds } }
 
     this.model
       .find(conditions)


### PR DESCRIPTION
Operators other than `$set` were being merged into the conditions for finding the updated documents post `updateMany`. This was resulting in MongoDB returning errors like "unknown top level operator: $push".

Storing the ids of the documents that are to be updated and using those to find them again after the update resolves the issue.

Related to https://github.com/codepunkt/mongoose-patch-history/pull/24.