### PR TITLE
Rollback without saving document

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,8 @@ exports.default = function (schema, opts) {
   schema.methods.rollback = function (patchId, data) {
     var _this = this;
 
+    var save = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
+
     return this.patches.find({ ref: this.id }).sort({ date: 1 }).exec().then(function (patches) {
       return new _bluebird2.default(function (resolve, reject) {
         // patch doesn't exist
@@ -63,7 +65,9 @@ exports.default = function (schema, opts) {
         });
 
         // save new state and resolve with the resulting document
-        _this.set((0, _lodash.merge)(data, state)).save().then(resolve).catch(reject);
+        _this.set((0, _lodash.merge)(data, state));
+
+        if (save) _this.save().then(resolve).catch(reject);else resolve(_this);
       });
     });
   };

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ export default function(schema, opts) {
   }
 
   // roll the document back to the state of a given patch id()
-  schema.methods.rollback = function(patchId, data) {
+  schema.methods.rollback = function(patchId, data, save = true) {
     return this.patches
       .find({ ref: this.id })
       .sort({ date: 1 })
@@ -105,9 +105,12 @@ export default function(schema, opts) {
 
             // save new state and resolve with the resulting document
             this.set(merge(data, state))
-              .save()
-              .then(resolve)
-              .catch(reject)
+
+            if (save)
+              this.save()
+                .then(resolve)
+                .catch(reject)
+            else resolve(this)
           })
       )
   }

--- a/test/index.js
+++ b/test/index.js
@@ -461,6 +461,28 @@ describe('mongoose-patch-history', () => {
         .then(done)
         .catch(done)
     })
+
+    it('updates but doesn\'t save the document', done => {
+      Comment.create({ text: 'comm 1', user: ObjectId() })
+        .then(c => Comment.findOne({ _id: c.id }))
+        .then(c => c.set({ text: 'comm 2', user: ObjectId() }).save())
+        .then(c => Comment.findOne({ _id: c.id }))
+        .then(c => c.set({ text: 'comm 3', user: ObjectId() }).save())
+        .then(c => Comment.findOne({ _id: c.id }))
+        .then(c => join(c, c.patches.find({ ref: c.id })))
+        .then(([c, patches]) => c.rollback(patches[1].id, { user: ObjectId() }, false))
+        .then(c => {
+          assert.equal(c.text, 'comm 2')
+          return Comment.findOne({ _id: c.id })
+        })
+        .then(c => {
+          assert.equal(c.text, 'comm 3')
+          return c.patches.find({ ref: c.id })
+        })
+        .then(patches => assert.equal(patches.length, 3))
+        .then(done)
+        .catch(done)
+    })
   })
 
   describe('model and collection names', () => {


### PR DESCRIPTION
Adds an option to rollback without saving the document. Useful for when you want to examine or display a previous state but don't want to actually mutate the document.