### PR TITLE
Adding excludes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ PostSchema.plugin(patchHistory, {
   An array of two functions that generate model and collection name based on the `name` option. Default: An array of [humps](https://github.com/domchristie/humps).pascalize and [humps](https://github.com/domchristie/humps).decamelize
 * `includes` <br/>
   Property definitions that will be included in the patch schema. Read more about includes in the next chapter of the documentation. Default: `{}`
+* `excludes` <br/>
+  Property paths that will be excluded in patches. Read more about excludes in the chapter after next. Default: `[]`
 * `trackOriginalValue` <br/>
   If enabled, the original value will be stored in the change patches under the attribute `originalValue`. Default: `false`
 
@@ -262,3 +264,36 @@ Post.findOneAndUpdate(
   { _user: mongoose.Types.ObjectId() }
 )
 ```
+
+### Excludes
+
+```javascript
+PostSchema.plugin(patchHistory, {
+  mongoose,
+  name: 'postPatches',
+  excludes: [
+    '/path/to/hidden/property',
+    '/path/into/array/*/property',
+    '/path/to/one/array/1/element'
+  ],
+})
+
+// Properties
+// /path/to/hidden:                   included
+// /path/to/hidden/property:          excluded
+// /path/to/hidden/property/nesting:  excluded
+
+// Array element properties
+// /path/into/array/0:                included
+// /path/into/array/345345/property:  excluded
+// /path/to/one/array/0/element:      included
+// /path/to/one/array/1/element:      excluded
+```
+
+This will exclude the given properties and *all nested* paths. Excluding `/` however will not work, since then you can just disable the plugin.
+
+- If a property is `{}` or `undefined` after processing all excludes statements, it will *not* be included in the patch.
+- Arrays work a little different. Since json-patch-operations work on the array index, array elements that are `{}` or `undefined` are still added to the patch. This brings support for later `remove` or `replace` operations to work as intended.<br/>
+  The `ARRAY_WILDCARD` `*` matches every array element.
+
+If there are any bugs experienced with the `excludes` feature please write an issue so we can fix it!

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To use **mongoose-patch-history** for an existing mongoose schema you can simply
 
 ```javascript
 import mongoose, { Schema } from 'mongoose'
-import patchHistory from 'mongoose-patch-history' 
+import patchHistory from 'mongoose-patch-history'
 
 /* or the following if not running your app with babel:
 const patchHistory = require('mongoose-patch-history').default;
@@ -148,8 +148,8 @@ post.rollback(patches[1].id, {}, false)
 
 The `rollback` method will throw an Error when invoked with an ObjectId that is
 
-* not a patch of the document
-* the latest patch of the document
+- not a patch of the document
+- the latest patch of the document
 
 ## Options
 
@@ -160,19 +160,19 @@ PostSchema.plugin(patchHistory, {
 })
 ```
 
-* `mongoose` :pushpin: _required_ <br/>
+- `mongoose` :pushpin: _required_ <br/>
   The mongoose instance to work with
-* `name` :pushpin: _required_ <br/>
+- `name` :pushpin: _required_ <br/>
   String where the names of both patch model and patch collection are generated from. By default, model name is the pascalized version and collection name is an undercore separated version
-* `removePatches` <br/>
+- `removePatches` <br/>
   Removes patches when origin document is removed. Default: `true`
-* `transforms` <br/>
+- `transforms` <br/>
   An array of two functions that generate model and collection name based on the `name` option. Default: An array of [humps](https://github.com/domchristie/humps).pascalize and [humps](https://github.com/domchristie/humps).decamelize
-* `includes` <br/>
+- `includes` <br/>
   Property definitions that will be included in the patch schema. Read more about includes in the next chapter of the documentation. Default: `{}`
-* `excludes` <br/>
-  Property paths that will be excluded in patches. Read more about excludes in the chapter after next. Default: `[]`
-* `trackOriginalValue` <br/>
+- `excludes` <br/>
+  Property paths that will be excluded in patches. Read more about excludes in the [excludes chapter of the documentation](https://github.com/codepunkt/mongoose-patch-history#excludes). Default: `[]`
+- `trackOriginalValue` <br/>
   If enabled, the original value will be stored in the change patches under the attribute `originalValue`. Default: `false`
 
 ### Includes
@@ -205,7 +205,7 @@ There is an additional option that allows storing information in the patch docum
 
 ```javascript
 // save user as _user in versioned documents
-PostSchema.virtual('user').set(function(user) {
+PostSchema.virtual('user').set(function (user) {
   this._user = user
 })
 
@@ -274,7 +274,7 @@ PostSchema.plugin(patchHistory, {
   excludes: [
     '/path/to/hidden/property',
     '/path/into/array/*/property',
-    '/path/to/one/array/1/element'
+    '/path/to/one/array/1/element',
   ],
 })
 
@@ -290,9 +290,9 @@ PostSchema.plugin(patchHistory, {
 // /path/to/one/array/1/element:      excluded
 ```
 
-This will exclude the given properties and *all nested* paths. Excluding `/` however will not work, since then you can just disable the plugin.
+This will exclude the given properties and _all nested_ paths. Excluding `/` however will not work, since then you can just disable the plugin.
 
-- If a property is `{}` or `undefined` after processing all excludes statements, it will *not* be included in the patch.
+- If a property is `{}` or `undefined` after processing all excludes statements, it will _not_ be included in the patch.
 - Arrays work a little different. Since json-patch-operations work on the array index, array elements that are `{}` or `undefined` are still added to the patch. This brings support for later `remove` or `replace` operations to work as intended.<br/>
   The `ARRAY_WILDCARD` `*` matches every array element.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -126,17 +126,17 @@ exports.default = function (schema, opts) {
     var queryOptions = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     var ref = document._id;
 
-    var ops = _fastJsonPatch2.default.compare(document.isNew ? {} : document._original || {}, toJSON(document.data())).filter(function (op) {
-      if (options.excludes.length > 0) {
+    var ops = _fastJsonPatch2.default.compare(document.isNew ? {} : document._original || {}, toJSON(document.data()));
+    if (options.excludes.length > 0) {
+      ops = ops.filter(function (op) {
         var pathArray = getArrayFromPath(op.path);
         return !options.excludes.some(function (exclude) {
           return isPathCovered(exclude, pathArray);
         }) && options.excludes.every(function (exclude) {
           return deepRemovePath(op, exclude);
         });
-      }
-      return true;
-    });
+      });
+    }
 
     // don't save a patch when there are no changes to save
     if (!ops.length) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -364,7 +364,7 @@ var getArrayFromPath = function getArrayFromPath(path) {
 };
 
 /**
- * Checks the provided `json-patch-operation` on `excludePath`. This check is joins the `path` and `value` property of the `operation` and removes any hit.
+ * Checks the provided `json-patch-operation` on `excludePath`. This check joins the `path` and `value` property of the `operation` and removes any hit.
  *
  * @param {import('fast-json-patch').Operation} patch operation to check with `excludePath`
  * @param {String[]} excludePath Path to property to remove from value of `operation`
@@ -374,22 +374,20 @@ var getArrayFromPath = function getArrayFromPath(path) {
 var deepRemovePath = function deepRemovePath(patch, excludePath) {
   var operationPath = sanitizeEmptyPath(getArrayFromPath(patch.path));
 
-  // first check if the base path of the json-patch overlaps with the path we want to exclude
   if (isPathContained(operationPath, excludePath)) {
     var value = patch.value;
 
     // because the paths overlap start at patchPath.length
-    // e.g.
-    // patch: { path:'/object', value:{ property: 'test' } }
+    // e.g.: patch: { path:'/object', value:{ property: 'test' } }
     // pathToExclude: '/object/property'
     // need to start at array idx 1, because value starts at idx 0
 
     var _loop = function _loop(i) {
       if (excludePath[i] === ARRAY_INDEX_WILDCARD && Array.isArray(value)) {
+        // start over with each array element and make a fresh check
+        // Note: it can happen that array elements are rendered to: {}
+        //         we need to keep them to keep the order of array elements consistent
         value.forEach(function (elem) {
-          // start over with each array element and make a fresh check
-          // Note: it can happen that array elements are rendered to: {}
-          //         we need to keep them to keep the order of array elements consistent
           deepRemovePath({ path: '/', value: elem }, excludePath.slice(i + 1));
         });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -360,8 +360,7 @@ var ARRAY_IDENTIFIER = '*';
  * @param {string} path Path to split
  */
 var getArrayFromPath = function getArrayFromPath(path) {
-  var pathArray = path.replace(/^\//, '').split('/');
-  if (pathArray.length === 1 && pathArray[0] === '') return [];else return pathArray;
+  return path.replace(/^\//, '').split('/');
 };
 
 /**
@@ -373,7 +372,7 @@ var getArrayFromPath = function getArrayFromPath(path) {
  * @return `false` if `patch.value` is `{}` or `undefined` after remove, `true` in any other case
  */
 var deepRemovePath = function deepRemovePath(patch, pathToExclude) {
-  var patchPath = getArrayFromPath(patch.path);
+  var patchPath = sanitizeEmptyPath(getArrayFromPath(patch.path));
 
   // first check if the base path of the json-patch overlaps with the path we want to exclude
   if (isPathCovered(patchPath, pathToExclude)) {
@@ -421,6 +420,14 @@ var deepRemovePath = function deepRemovePath(patch, pathToExclude) {
     }
   }
   return true;
+};
+
+/**
+ * Sanitizes a path `['']` to be used with `isPathCovered()`
+ * @param {String[]} path
+ */
+var sanitizeEmptyPath = function sanitizeEmptyPath(path) {
+  return path.length === 1 && path[0] === '' ? [] : path;
 };
 
 // Checks if 'pathToCover' is covered by path

--- a/lib/index.js
+++ b/lib/index.js
@@ -131,7 +131,7 @@ exports.default = function (schema, opts) {
       ops = ops.filter(function (op) {
         var pathArray = getArrayFromPath(op.path);
         return !options.excludes.some(function (exclude) {
-          return isPathCovered(exclude, pathArray);
+          return isPathContained(exclude, pathArray);
         }) && options.excludes.every(function (exclude) {
           return deepRemovePath(op, exclude);
         });
@@ -351,7 +351,7 @@ var defaultOptions = {
   trackOriginalValue: false
 };
 
-var ARRAY_IDENTIFIER = '*';
+var ARRAY_INDEX_WILDCARD = '*';
 
 /**
  * Splits a json-patch-path of form `/path/to/object` to an array `['path', 'to', 'object']`.
@@ -364,18 +364,18 @@ var getArrayFromPath = function getArrayFromPath(path) {
 };
 
 /**
- * Checks the provided `json-patch-operation` on `pathToExclude`. This check is joins the `path` and `value` property of the `operation` and removes any hit.
+ * Checks the provided `json-patch-operation` on `excludePath`. This check is joins the `path` and `value` property of the `operation` and removes any hit.
  *
- * @param {import('fast-json-patch').Operation} patch operation to check with `pathToExclude`
- * @param {String[]} pathToExclude Path to property to remove from value of `operation`
+ * @param {import('fast-json-patch').Operation} patch operation to check with `excludePath`
+ * @param {String[]} excludePath Path to property to remove from value of `operation`
  *
  * @return `false` if `patch.value` is `{}` or `undefined` after remove, `true` in any other case
  */
-var deepRemovePath = function deepRemovePath(patch, pathToExclude) {
-  var patchPath = sanitizeEmptyPath(getArrayFromPath(patch.path));
+var deepRemovePath = function deepRemovePath(patch, excludePath) {
+  var operationPath = sanitizeEmptyPath(getArrayFromPath(patch.path));
 
   // first check if the base path of the json-patch overlaps with the path we want to exclude
-  if (isPathCovered(patchPath, pathToExclude)) {
+  if (isPathContained(operationPath, excludePath)) {
     var value = patch.value;
 
     // because the paths overlap start at patchPath.length
@@ -385,12 +385,12 @@ var deepRemovePath = function deepRemovePath(patch, pathToExclude) {
     // need to start at array idx 1, because value starts at idx 0
 
     var _loop = function _loop(i) {
-      if (pathToExclude[i] === ARRAY_IDENTIFIER && Array.isArray(value)) {
+      if (excludePath[i] === ARRAY_INDEX_WILDCARD && Array.isArray(value)) {
         value.forEach(function (elem) {
           // start over with each array element and make a fresh check
           // Note: it can happen that array elements are rendered to: {}
           //         we need to keep them to keep the order of array elements consistent
-          deepRemovePath({ path: '/', value: elem }, pathToExclude.slice(i + 1));
+          deepRemovePath({ path: '/', value: elem }, excludePath.slice(i + 1));
         });
 
         // If the patch value has turned to {} return false so this patch can be filtered out
@@ -401,20 +401,20 @@ var deepRemovePath = function deepRemovePath(patch, pathToExclude) {
           v: true
         };
       }
-      value = value[pathToExclude[i]];
+      value = value[excludePath[i]];
 
       if (typeof value === 'undefined') return {
           v: true
         };
     };
 
-    for (var i = patchPath.length; i < pathToExclude.length - 1; i++) {
+    for (var i = operationPath.length; i < excludePath.length - 1; i++) {
       var _ret = _loop(i);
 
       if ((typeof _ret === 'undefined' ? 'undefined' : _typeof(_ret)) === "object") return _ret.v;
     }
-    if (typeof value[pathToExclude[pathToExclude.length - 1]] === 'undefined') return true;else {
-      delete value[pathToExclude[pathToExclude.length - 1]];
+    if (typeof value[excludePath[excludePath.length - 1]] === 'undefined') return true;else {
+      delete value[excludePath[excludePath.length - 1]];
       // If the patch value has turned to {} return false so this patch can be filtered out
       if (Object.keys(patch.value).length === 0) return false;
     }
@@ -423,20 +423,36 @@ var deepRemovePath = function deepRemovePath(patch, pathToExclude) {
 };
 
 /**
- * Sanitizes a path `['']` to be used with `isPathCovered()`
+ * Sanitizes a path `['']` to be used with `isPathContained()`
  * @param {String[]} path
  */
 var sanitizeEmptyPath = function sanitizeEmptyPath(path) {
   return path.length === 1 && path[0] === '' ? [] : path;
 };
 
-// Checks if 'pathToCover' is covered by path
-// Exp. 1: path '/path/to',              pathToCover '/path/to/object'       => true
-// Exp. 2: path '/arrayPath/*/property', pathToCover '/arrayPath/1/property' => true
-var isPathCovered = function isPathCovered(path, pathToCover) {
-  return path.every(function (entry, idx) {
-    return entry === pathToCover[idx] || entry === '*' && Number.isInteger(Number(pathToCover[idx])) && Number(pathToCover[idx]) >= 0;
+// Checks if 'fractionPath' is contained in fullPath
+// Exp. 1: fractionPath '/path/to',              fullPath '/path/to/object'       => true
+// Exp. 2: fractionPath '/arrayPath/*/property', fullPath '/arrayPath/1/property' => true
+var isPathContained = function isPathContained(fractionPath, fullPath) {
+  return fractionPath.every(function (entry, idx) {
+    return entryIsIdentical(entry, fullPath[idx]) || matchesArrayWildcard(entry, fullPath[idx]);
   });
+};
+
+var entryIsIdentical = function entryIsIdentical(entry1, entry2) {
+  return entry1 === entry2;
+};
+
+var matchesArrayWildcard = function matchesArrayWildcard(entry1, entry2) {
+  return isArrayIndexWildcard(entry1) && isIntegerGreaterEqual0(entry2);
+};
+
+var isArrayIndexWildcard = function isArrayIndexWildcard(entry) {
+  return entry === ARRAY_INDEX_WILDCARD;
+};
+
+var isIntegerGreaterEqual0 = function isIntegerGreaterEqual0(entry) {
+  return Number.isInteger(Number(entry)) && Number(entry) >= 0;
 };
 
 // used to convert bson to json - especially ObjectID references need

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,11 +5,16 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.RollbackError = undefined;
 
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
 exports.default = function (schema, opts) {
   var options = (0, _lodash.merge)({}, defaultOptions, opts);
 
   // get _id type from schema
   options._idType = schema.tree._id.type;
+
+  // transform excludes option
+  options.excludes = options.excludes.map(getArrayFromPath);
 
   // validate parameters
   (0, _assert2.default)(options.mongoose, '`mongoose` option must be defined');
@@ -121,7 +126,17 @@ exports.default = function (schema, opts) {
     var queryOptions = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     var ref = document._id;
 
-    var ops = _fastJsonPatch2.default.compare(document.isNew ? {} : document._original || {}, toJSON(document.data()));
+    var ops = _fastJsonPatch2.default.compare(document.isNew ? {} : document._original || {}, toJSON(document.data())).filter(function (op) {
+      if (options.excludes.length > 0) {
+        var pathArray = getArrayFromPath(op.path);
+        return !options.excludes.some(function (exclude) {
+          return isPathCovered(exclude, pathArray);
+        }) && options.excludes.every(function (exclude) {
+          return deepRemovePath(op, exclude);
+        });
+      }
+      return true;
+    });
 
     // don't save a patch when there are no changes to save
     if (!ops.length) {
@@ -330,14 +345,97 @@ var createPatchModel = function createPatchModel(options) {
 
 var defaultOptions = {
   includes: {},
+  excludes: [],
   removePatches: true,
   transforms: [_humps.pascalize, _humps.decamelize],
   trackOriginalValue: false
+};
 
-  // used to convert bson to json - especially ObjectID references need
-  // to be converted to hex strings so that the jsonpatch `compare` method
-  // works correctly
-};var toJSON = function toJSON(obj) {
+var ARRAY_IDENTIFIER = '*';
+
+/**
+ * Splits a json-patch-path of form `/path/to/object` to an array `['path', 'to', 'object']`.
+ * Note: `/` is returned as `[]`
+ *
+ * @param {string} path Path to split
+ */
+var getArrayFromPath = function getArrayFromPath(path) {
+  var pathArray = path.replace(/^\//, '').split('/');
+  if (pathArray.length === 1 && pathArray[0] === '') return [];else return pathArray;
+};
+
+/**
+ * Checks the provided `json-patch-operation` on `pathToExclude`. This check is joins the `path` and `value` property of the `operation` and removes any hit.
+ *
+ * @param {import('fast-json-patch').Operation} patch operation to check with `pathToExclude`
+ * @param {String[]} pathToExclude Path to property to remove from value of `operation`
+ *
+ * @return `false` if `patch.value` is `{}` or `undefined` after remove, `true` in any other case
+ */
+var deepRemovePath = function deepRemovePath(patch, pathToExclude) {
+  var patchPath = getArrayFromPath(patch.path);
+
+  // first check if the base path of the json-patch overlaps with the path we want to exclude
+  if (isPathCovered(patchPath, pathToExclude)) {
+    var value = patch.value;
+
+    // because the paths overlap start at patchPath.length
+    // e.g.
+    // patch: { path:'/object', value:{ property: 'test' } }
+    // pathToExclude: '/object/property'
+    // need to start at array idx 1, because value starts at idx 0
+
+    var _loop = function _loop(i) {
+      if (pathToExclude[i] === ARRAY_IDENTIFIER && Array.isArray(value)) {
+        value.forEach(function (elem) {
+          // start over with each array element and make a fresh check
+          // Note: it can happen that array elements are rendered to: {}
+          //         we need to keep them to keep the order of array elements consistent
+          deepRemovePath({ path: '/', value: elem }, pathToExclude.slice(i + 1));
+        });
+
+        // If the patch value has turned to {} return false so this patch can be filtered out
+        if (Object.keys(patch.value).length === 0) return {
+            v: false
+          };
+        return {
+          v: true
+        };
+      }
+      value = value[pathToExclude[i]];
+
+      if (typeof value === 'undefined') return {
+          v: true
+        };
+    };
+
+    for (var i = patchPath.length; i < pathToExclude.length - 1; i++) {
+      var _ret = _loop(i);
+
+      if ((typeof _ret === 'undefined' ? 'undefined' : _typeof(_ret)) === "object") return _ret.v;
+    }
+    if (typeof value[pathToExclude[pathToExclude.length - 1]] === 'undefined') return true;else {
+      delete value[pathToExclude[pathToExclude.length - 1]];
+      // If the patch value has turned to {} return false so this patch can be filtered out
+      if (Object.keys(patch.value).length === 0) return false;
+    }
+  }
+  return true;
+};
+
+// Checks if 'pathToCover' is covered by path
+// Exp. 1: path '/path/to',              pathToCover '/path/to/object'       => true
+// Exp. 2: path '/arrayPath/*/property', pathToCover '/arrayPath/1/property' => true
+var isPathCovered = function isPathCovered(path, pathToCover) {
+  return path.every(function (entry, idx) {
+    return entry === pathToCover[idx] || entry === '*' && Number.isInteger(Number(pathToCover[idx])) && Number(pathToCover[idx]) >= 0;
+  });
+};
+
+// used to convert bson to json - especially ObjectID references need
+// to be converted to hex strings so that the jsonpatch `compare` method
+// works correctly
+var toJSON = function toJSON(obj) {
   return JSON.parse(JSON.stringify(obj));
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ const ARRAY_INDEX_WILDCARD = '*'
 const getArrayFromPath = path => path.replace(/^\//, '').split('/')
 
 /**
- * Checks the provided `json-patch-operation` on `excludePath`. This check is joins the `path` and `value` property of the `operation` and removes any hit.
+ * Checks the provided `json-patch-operation` on `excludePath`. This check joins the `path` and `value` property of the `operation` and removes any hit.
  *
  * @param {import('fast-json-patch').Operation} patch operation to check with `excludePath`
  * @param {String[]} excludePath Path to property to remove from value of `operation`
@@ -62,21 +62,19 @@ const getArrayFromPath = path => path.replace(/^\//, '').split('/')
 const deepRemovePath = (patch, excludePath) => {
   const operationPath = sanitizeEmptyPath(getArrayFromPath(patch.path))
 
-  // first check if the base path of the json-patch overlaps with the path we want to exclude
   if (isPathContained(operationPath, excludePath)) {
     let value = patch.value
 
     // because the paths overlap start at patchPath.length
-    // e.g.
-    // patch: { path:'/object', value:{ property: 'test' } }
+    // e.g.: patch: { path:'/object', value:{ property: 'test' } }
     // pathToExclude: '/object/property'
     // need to start at array idx 1, because value starts at idx 0
     for (let i = operationPath.length; i < excludePath.length - 1; i++) {
       if (excludePath[i] === ARRAY_INDEX_WILDCARD && Array.isArray(value)) {
+        // start over with each array element and make a fresh check
+        // Note: it can happen that array elements are rendered to: {}
+        //         we need to keep them to keep the order of array elements consistent
         value.forEach(elem => {
-          // start over with each array element and make a fresh check
-          // Note: it can happen that array elements are rendered to: {}
-          //         we need to keep them to keep the order of array elements consistent
           deepRemovePath({ path: '/', value: elem }, excludePath.slice(i + 1))
         })
 

--- a/src/index.js
+++ b/src/index.js
@@ -49,11 +49,7 @@ const ARRAY_IDENTIFIER = '*'
  *
  * @param {string} path Path to split
  */
-const getArrayFromPath = path => {
-  const pathArray = path.replace(/^\//, '').split('/')
-  if (pathArray.length === 1 && pathArray[0] === '') return []
-  else return pathArray
-}
+const getArrayFromPath = path => path.replace(/^\//, '').split('/')
 
 /**
  * Checks the provided `json-patch-operation` on `pathToExclude`. This check is joins the `path` and `value` property of the `operation` and removes any hit.
@@ -64,7 +60,7 @@ const getArrayFromPath = path => {
  * @return `false` if `patch.value` is `{}` or `undefined` after remove, `true` in any other case
  */
 const deepRemovePath = (patch, pathToExclude) => {
-  const patchPath = getArrayFromPath(patch.path)
+  const patchPath = sanitizeEmptyPath(getArrayFromPath(patch.path))
 
   // first check if the base path of the json-patch overlaps with the path we want to exclude
   if (isPathCovered(patchPath, pathToExclude)) {
@@ -102,6 +98,13 @@ const deepRemovePath = (patch, pathToExclude) => {
   }
   return true
 }
+
+/**
+ * Sanitizes a path `['']` to be used with `isPathCovered()`
+ * @param {String[]} path
+ */
+const sanitizeEmptyPath = path =>
+  path.length === 1 && path[0] === '' ? [] : path
 
 // Checks if 'pathToCover' is covered by path
 // Exp. 1: path '/path/to',              pathToCover '/path/to/object'       => true

--- a/src/index.js
+++ b/src/index.js
@@ -245,22 +245,20 @@ export default function(schema, opts) {
   // added to the associated patch collection
   function createPatch(document, queryOptions = {}) {
     const { _id: ref } = document
-    const ops = jsonpatch
-      .compare(
-        document.isNew ? {} : document._original || {},
-        toJSON(document.data())
-      )
-      .filter(op => {
-        if (options.excludes.length > 0) {
-          const pathArray = getArrayFromPath(op.path)
-          return (
-            !options.excludes.some(exclude =>
-              isPathCovered(exclude, pathArray)
-            ) && options.excludes.every(exclude => deepRemovePath(op, exclude))
-          )
-        }
-        return true
+    let ops = jsonpatch.compare(
+      document.isNew ? {} : document._original || {},
+      toJSON(document.data())
+    )
+    if (options.excludes.length > 0) {
+      ops = ops.filter(op => {
+        const pathArray = getArrayFromPath(op.path)
+        return (
+          !options.excludes.some(exclude =>
+            isPathCovered(exclude, pathArray)
+          ) && options.excludes.every(exclude => deepRemovePath(op, exclude))
+        )
       })
+    }
 
     // don't save a patch when there are no changes to save
     if (!ops.length) {


### PR DESCRIPTION
This PR adds an `excludes: []` option which can be used to exclude certain paths of the versioned object from being versioned.

Excludes are defined as follows
```js
ExcludeSchema.plugin(patchHistory, {
  mongoose,
  name: 'excludePatches',
  excludes: ['/hidden', '/object/hiddenProperty', '/array/*/hiddenProperty'],
})
```
A exclude of `/hidden` would exclude all paths that start with `/hidden`.
For arrays I introduced the `*` symbol to specifiy a specific property inside the array to be excluded. One could ofcourse also specify a number to only exclude one array element.

#### Problems
Add the moment I have one failing test. This tests what patches are written when an object is saved initially.
At the moment I do the comparison on the `path`-property of the `json-patch`. Since `json-patch` adds only the top-level-properties when an object is added: e.g. `op:'add', path:'/object', value:'{ hiddenProperty: 'test' }'` it would take a little more effort to make the exclude work for this kind of operation.

@codepunkt Do you think this behaviour would be necessary for consistency or can we only support the `excludes` option for updates() and not for initial writing?