### PR TITLE
Rollback without saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ Post.create({ title: 'JSON patches' })
 
 ### Rollback to a specific patch
 
+```javascript
+rollback(ObjectId, data, save)
+```
+
 Documents have a `rollback` method that accepts the _ObjectId_ of a patch doc and sets the document to the state of that patch, adding a new patch to the history.
 
 ```javascript
@@ -105,6 +109,36 @@ Post.create({ title: 'First version' })
   })
   .then(console.log)
 
+// {
+//   _id: ObjectId('4edd40c86762e0fb12000006'),
+//   title: 'Second version',
+//   __v: 0
+// }
+```
+
+#### Injecting data
+
+Further the `rollback` method accepts a _data_ object which is injected into the document.
+
+```javascript
+post.rollback(patches[1].id, { name: 'merged' })
+
+// {
+//   _id: ObjectId('4edd40c86762e0fb12000006'),
+//   title: 'Second version',
+//   name: 'merged',
+//   __v: 0
+// }
+```
+
+#### Rollback without saving
+
+To `rollback` the document to a specific patch but without saving it back to the database call the method with an empty _data_ object and the save flag set to false.
+
+```javascript
+post.rollback(patches[1].id, {}, false)
+
+// Returns the document without saving it back to the db.
 // {
 //   _id: ObjectId('4edd40c86762e0fb12000006'),
 //   title: 'Second version',
@@ -196,7 +230,7 @@ Post.create({
   })
 ```
 
-In case of a rollback in this scenario, the `rollback` method accepts an object as its second parameter where additional data can be injected:
+In case of a rollback in this scenario, the `rollback` method accepts an [object as its second parameter](https://github.com/codepunkt/mongoose-patch-history#injecting-data) where additional data can be injected:
 
 ```javascript
 Post.create({ title: 'v1', user: mongoose.Types.ObjectId() })

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,8 @@ exports.default = function (schema, opts) {
   schema.methods.rollback = function (patchId, data) {
     var _this = this;
 
+    var save = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
+
     return this.patches.find({ ref: this.id }).sort({ date: 1 }).exec().then(function (patches) {
       return new _bluebird2.default(function (resolve, reject) {
         // patch doesn't exist
@@ -62,8 +64,13 @@ exports.default = function (schema, opts) {
           _fastJsonPatch2.default.applyPatch(state, patch.ops, true);
         });
 
-        // save new state and resolve with the resulting document
-        _this.set((0, _lodash.merge)(data, state)).save().then(resolve).catch(reject);
+        // set new state
+        _this.set((0, _lodash.merge)(data, state));
+
+        // in case of save, save it back to the db and resolve
+        if (save) {
+          _this.save().then(resolve).catch(reject);
+        } else resolve(_this);
       });
     });
   };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
         {
             "name": "Brett Ausmeier",
             "email": "brett@ausmeier.co.za"
+        },
+        {
+            "name": "Ava Johnson"
         }
     ],
     "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,7 @@ export default function(schema, opts) {
   }
 
   // roll the document back to the state of a given patch id()
-  schema.methods.rollback = function(patchId, data) {
+  schema.methods.rollback = function (patchId, data, save = true) {
     return this.patches
       .find({ ref: this.id })
       .sort({ date: 1 })
@@ -117,11 +117,13 @@ export default function(schema, opts) {
               jsonpatch.applyPatch(state, patch.ops, true)
             })
 
-            // save new state and resolve with the resulting document
+            // set new state
             this.set(merge(data, state))
-              .save()
-              .then(resolve)
-              .catch(reject)
+
+            // in case of save, save it back to the db and resolve
+            if (save) {
+              this.save().then(resolve).catch(reject)
+            } else resolve(this)
           })
       )
   }


### PR DESCRIPTION
Add an additional option to `rollback(objectID, data, save)` to rollback the document to a specified PatchID but without saving it back to the DB.
Useful for examining an older state of a document.

Code borrowed from #35.