### PR TITLE
Fixed undefined document with mongoose options (new && rawResult)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -197,6 +197,10 @@ exports.default = function (schema, opts) {
       return postUpdateOne.call(this, {}, next);
     }
 
+    if (this.options.new && this.options.rawResult) {
+      doc = doc.value;
+    }
+
     doc._original = this._original;
     createPatch(doc, this.options).then(function () {
       return next();

--- a/src/index.js
+++ b/src/index.js
@@ -335,6 +335,10 @@ export default function (schema, opts) {
       return postUpdateOne.call(this, {}, next)
     }
 
+    if (this.options.new && this.options.rawResult) {
+      doc = doc.value
+    }
+
     doc._original = this._original
     createPatch(doc, this.options)
       .then(() => next())

--- a/test/index.js
+++ b/test/index.js
@@ -371,6 +371,16 @@ describe('mongoose-patch-history', () => {
         })
         .catch(done)
     })
+
+    it('should work with options { new:true, rawResult:true }', (done) => {
+      Post.findOneAndUpdate(
+        { title: 'findOneAndUpdate2' },
+        { title: 'findOneAndUpdate1' },
+        { new: true, rawResult: true }
+      )
+        .then(() => done())
+        .catch(done)
+    })
   })
 
   describe('updating a document via updateOne()', () => {


### PR DESCRIPTION
Hey @codepunkt ! Hope you are well 😄 (#69)

[Mongoose](https://mongoosejs.com/docs/tutorials/findoneandupdate.html#raw-result) `findOneAndUpdate` accepts several options including `new` and `rawResult`.
Used alone, these options return the document as expect. Used together however, not the document is returned and used in the plugin callbacks but an object of this format
```js
{
  lastErrorObject: { n: 1, updatedExisting: true },
  value: {
    _id: 5f6cfd8a45d0cb26f8f71a86,
    title: 'foo',
    createdAt: 2020-09-24T20:11:54.779Z,
    updatedAt: 2020-09-24T20:11:54.877Z,
    __v: 0
  },
  ok: 1,
}
```
As one can see the wanted document is contained inside the `value` property.

I don't know if this can happen in more than the `findOneAndUpdate` query. And tbh I'm not in the mood to search the code for possible places it *can* happen.
IMHO this fix can be included as is since the probability that anybody will ran into a similiar issue is low enough.