### PR TITLE
Adapt to changed mongoose behaviour

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -210,7 +210,7 @@ exports.default = function (schema, opts) {
   function postUpdateOne(result, next) {
     var _this3 = this;
 
-    if (result.nModified === 0) return;
+    if (result.nModified === 0 && !result.upserted) return next();
 
     var conditions = void 0;
     if (this._originalId) conditions = { _id: { $eq: this._originalId } };else conditions = mergeQueryConditionsWithUpdate(this._conditions, this._update);
@@ -269,7 +269,7 @@ exports.default = function (schema, opts) {
   function postUpdateMany(result, next) {
     var _this5 = this;
 
-    if (result.nModified === 0) return;
+    if (result.nModified === 0 && !result.upserted) return next();
 
     var conditions = void 0;
     if (this._originalIds.length === 0) conditions = mergeQueryConditionsWithUpdate(this._conditions, this._update);else conditions = { _id: { $in: this._originalIds } };

--- a/package-lock.json
+++ b/package-lock.json
@@ -925,6 +925,63 @@
             "dev": true,
             "optional": true
         },
+        "bl": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+            "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+            "requires": {
+                "readable-stream": "^2.3.5",
+                "safe-buffer": "^5.1.1"
+            },
+            "dependencies": {
+                "process-nextick-args": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+                    "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+                },
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    },
+                    "dependencies": {
+                        "safe-buffer": {
+                            "version": "5.1.2",
+                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                        }
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    },
+                    "dependencies": {
+                        "safe-buffer": {
+                            "version": "5.1.2",
+                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                        }
+                    }
+                }
+            }
+        },
         "block-stream": {
             "version": "0.0.9",
             "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -1093,8 +1150,7 @@
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-            "dev": true
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "coveralls": {
             "version": "3.0.0",
@@ -1199,6 +1255,11 @@
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
             "dev": true
+        },
+        "denque": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+            "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
         },
         "detect-indent": {
             "version": "4.0.0",
@@ -2685,8 +2746,7 @@
         "inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-            "dev": true
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
             "version": "1.3.5",
@@ -2870,8 +2930,7 @@
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-            "dev": true
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "isexe": {
             "version": "2.0.0",
@@ -3163,6 +3222,12 @@
             "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
             "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
             "dev": true,
+            "optional": true
+        },
+        "memory-pager": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+            "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
             "optional": true
         },
         "micromatch": {
@@ -3535,13 +3600,16 @@
             }
         },
         "mongodb": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.3.2.tgz",
-            "integrity": "sha512-fqJt3iywelk4yKu/lfwQg163Bjpo5zDKhXiohycvon4iQHbrfflSAz9AIlRE6496Pm/dQKQK5bMigdVo2s6gBg==",
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.2.tgz",
+            "integrity": "sha512-sSZOb04w3HcnrrXC82NEh/YGCmBuRgR+C1hZgmmv4L6dBz4BkRse6Y8/q/neXer9i95fKUBbFi4KgeceXmbsOA==",
             "requires": {
-                "bson": "^1.1.1",
+                "bl": "^2.2.1",
+                "bson": "^1.1.4",
+                "denque": "^1.4.1",
                 "require_optional": "^1.0.1",
-                "safe-buffer": "^5.1.2"
+                "safe-buffer": "^5.1.2",
+                "saslprep": "^1.0.0"
             },
             "dependencies": {
                 "safe-buffer": {
@@ -3552,19 +3620,19 @@
             }
         },
         "mongoose": {
-            "version": "5.7.5",
-            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.7.5.tgz",
-            "integrity": "sha512-BZ4FxtnbTurc/wcm/hLltLdI4IDxo4nsE0D9q58YymTdZwreNzwO62CcjVtaHhmr8HmJtOInp2W/T12FZaMf8g==",
+            "version": "5.10.7",
+            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.10.7.tgz",
+            "integrity": "sha512-oiofFrD4I5p3PhJXn49QyrU1nX5CY01qhPkfMMrXYPhkfGLEJVwFVO+0PsCxD91A2kQP+d/iFyk5U8e86KI8eQ==",
             "requires": {
-                "bson": "~1.1.1",
+                "bson": "^1.1.4",
                 "kareem": "2.3.1",
-                "mongodb": "3.3.2",
+                "mongodb": "3.6.2",
                 "mongoose-legacy-pluralize": "1.0.2",
-                "mpath": "0.6.0",
+                "mpath": "0.7.0",
                 "mquery": "3.2.2",
                 "ms": "2.1.2",
                 "regexp-clone": "1.0.0",
-                "safe-buffer": "5.1.2",
+                "safe-buffer": "5.2.1",
                 "sift": "7.0.1",
                 "sliced": "1.0.1"
             },
@@ -3575,9 +3643,9 @@
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 },
                 "safe-buffer": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
                 }
             }
         },
@@ -3587,9 +3655,9 @@
             "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
         },
         "mpath": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.6.0.tgz",
-            "integrity": "sha512-i75qh79MJ5Xo/sbhxrDrPSEG0H/mr1kcZXJ8dH6URU5jD/knFxCVqVC/gVSW7GIXL/9hHWlT9haLbCXWOll3qw=="
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.7.0.tgz",
+            "integrity": "sha512-Aiq04hILxhz1L+f7sjGyn7IxYzWm1zLNNXcfhDtx04kZ2Gk7uvFdgZ8ts1cWa/6d0TQmag2yR8zSGZUmp0tFNg=="
         },
         "mquery": {
             "version": "3.2.2",
@@ -4167,6 +4235,15 @@
             "dev": true,
             "optional": true
         },
+        "saslprep": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+            "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+            "optional": true,
+            "requires": {
+                "sparse-bitfield": "^3.0.3"
+            }
+        },
         "semver": {
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -4247,6 +4324,15 @@
             "dev": true,
             "requires": {
                 "source-map": "^0.5.6"
+            }
+        },
+        "sparse-bitfield": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+            "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+            "optional": true,
+            "requires": {
+                "memory-pager": "^1.0.2"
             }
         },
         "spawn-sync": {
@@ -4479,8 +4565,7 @@
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-            "dev": true
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "uuid": {
             "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "fast-json-patch": "^2.2.1",
     "humps": "^2.0.1",
     "lodash": "^4.17.20",
-    "mongoose": "^5.6.2"
+    "mongoose": "^5.10.7"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/index.js
+++ b/src/index.js
@@ -346,7 +346,7 @@ export default function (schema, opts) {
   })
 
   function postUpdateOne(result, next) {
-    if (result.nModified === 0) return
+    if (result.nModified === 0 && !result.upserted) return next()
 
     let conditions
     if (this._originalId) conditions = { _id: { $eq: this._originalId } }
@@ -388,7 +388,7 @@ export default function (schema, opts) {
   }
 
   function postUpdateMany(result, next) {
-    if (result.nModified === 0) return
+    if (result.nModified === 0 && !result.upserted) return next()
 
     let conditions
     if (this._originalIds.length === 0)


### PR DESCRIPTION
## Summary (Fixes #71)

- Bumps mongoose to newest version
- Adapts to mongoose changes

## Explanation

Somewhere along the versions 5.9 to 5.10 several changes where introduced:

- Plugin hook functions must (!) call next(), simply calling return while leave a non-returning promise.
- When upserting a document the query result changed from { nModified: 1, ... } to { nModified: 0, upserted: [docs], ... }

So I changed the nModified check to include the new upserted property and am calling next() to return.

## Additional

In #72 I tested my fix on different mongoose versions and it passed on both. I also tested with more versions on my machine.
However this tests are not included into CI. I'm not sure if running 30 different version combinations is a good way to go.

I would propose to include Node v14 in the test, but only run with the newest mongoose versions. Your opinion @codepunkt?