### PR TITLE
Always use mongoose instance from options.mongoose

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -307,8 +307,6 @@ var _assert = require('assert');
 
 var _assert2 = _interopRequireDefault(_assert);
 
-var _mongoose = require('mongoose');
-
 var _bluebird = require('bluebird');
 
 var _bluebird2 = _interopRequireDefault(_bluebird);
@@ -342,7 +340,7 @@ var createPatchModel = function createPatchModel(options) {
     def[name] = (0, _lodash.omit)(type, 'from');
   });
 
-  var PatchSchema = new _mongoose.Schema(def);
+  var PatchSchema = new options.mongoose.Schema(def);
 
   return options.mongoose.model(options.transforms[0]('' + options.name), PatchSchema, options.transforms[1]('' + options.name));
 };


### PR DESCRIPTION
I use various plugins to add additional data types in my Mongoose config. For example we use uuid _id fields. This is all fine and plugs in very well but this project seems to use their own mongoose instance for creating the schema. Which breaks the _id field with uuid support.

This PR fixes that, does this cause any problems?