### PR TITLE
Always use mongoose instance from options.mongoose

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import assert from 'assert'
-import { Schema } from 'mongoose'
 import Promise, { join } from 'bluebird'
 import jsonpatch from 'fast-json-patch'
 import { decamelize, pascalize } from 'humps'
@@ -24,7 +23,7 @@ const createPatchModel = (options) => {
     def[name] = omit(type, 'from')
   })
 
-  const PatchSchema = new Schema(def)
+  const PatchSchema = new options.mongoose.Schema(def)
 
   return options.mongoose.model(
     options.transforms[0](`${options.name}`),


### PR DESCRIPTION
I use various plugins to add additional data types in my Mongoose config. For example we use uuid _id fields. This is all fine and plugs in very well but this project seems to use their own mongoose instance for creating the schema. Which breaks the _id field with uuid support.

This PR fixes that, does this cause any problems?