### PR TITLE
fix: upsert with multi property

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -295,7 +295,7 @@ exports.default = function (schema, opts) {
     }
   });
   schema.post('update', function (result, next) {
-    if (this.options.many) {
+    if (this.options.multi) {
       postUpdateMany.call(this, result, next);
     } else {
       postUpdateOne.call(this, result, next);

--- a/src/index.js
+++ b/src/index.js
@@ -423,7 +423,7 @@ export default function (schema, opts) {
     }
   })
   schema.post('update', function (result, next) {
-    if (this.options.many) {
+    if (this.options.multi) {
       postUpdateMany.call(this, result, next)
     } else {
       postUpdateOne.call(this, result, next)

--- a/test/index.js
+++ b/test/index.js
@@ -545,7 +545,7 @@ describe('mongoose-patch-history', () => {
         .catch(done)
     })
 
-    it('without changes: adds a patch', (done) => {
+    it('without changes: doesn\'t add a patch', (done) => {
       Post.update(
         { title: 'upsert1' },
         { title: 'upsert1' },
@@ -554,7 +554,7 @@ describe('mongoose-patch-history', () => {
         .then(() => Post.find({ title: 'upsert1' }))
         .then((posts) => posts[0].patches.find({ ref: posts[0].id }))
         .then((patches) => {
-          assert.equal(patches.length, 2)
+          assert.equal(patches.length, 1)
         })
         .then(done)
         .catch(done)


### PR DESCRIPTION
When upserting a document *without changes* with `multi: true`, a patch is added as stayed by the [test](https://github.com/codepunkt/mongoose-patch-history/compare/fix-upsert-multi?expand=1#diff-5bb8db779819ddef5956a5d9d5949c05ef7445237656ca37bf2f02720271440bL548).

This is however a wrong behavior as no patch should be added when no changes are present. This faulty behavior is cause by a leftover variable name change from `many` to `multi`. Which caused the wrong hooks to be executed.