### PR TITLE
Fix "cannot set property _original of null" error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -193,18 +193,7 @@ exports.default = function (schema, opts) {
   }
 
   schema.post('findOneAndUpdate', function (doc, next) {
-    if (!this.options.new) {
-      return postUpdateOne.call(this, {}, next);
-    }
-
-    if (this.options.new && this.options.rawResult) {
-      doc = doc.value;
-    }
-
-    doc._original = this._original;
-    createPatch(doc, this.options).then(function () {
-      return next();
-    }).catch(next);
+    return postUpdateOne.call(this, {}, next);
   });
 
   function postUpdateOne(result, next) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import assert from 'assert'
 import jsonpatch from 'fast-json-patch'
 import { decamelize, pascalize } from 'humps'
-import { dropRightWhile, each, map, merge, omit, get, tail } from 'lodash'
+import { dropRightWhile, each, get, map, merge, omit, tail } from 'lodash'
 
 export const RollbackError = function (message, extra) {
   Error.captureStackTrace(this, this.constructor)
@@ -329,18 +329,7 @@ export default function (schema, opts) {
   }
 
   schema.post('findOneAndUpdate', function (doc, next) {
-    if (!this.options.new) {
-      return postUpdateOne.call(this, {}, next)
-    }
-
-    if (this.options.new && this.options.rawResult) {
-      doc = doc.value
-    }
-
-    doc._original = this._original
-    createPatch(doc, this.options)
-      .then(() => next())
-      .catch(next)
+    return postUpdateOne.call(this, {}, next)
   })
 
   function postUpdateOne(result, next) {

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 import assert from 'assert'
-import { map, random } from 'lodash'
 import Promise, { join } from 'bluebird'
+import { map, random } from 'lodash'
 import mongoose, { Schema } from 'mongoose'
 import patchHistory, { RollbackError } from '../src'
 
@@ -372,6 +372,28 @@ describe('mongoose-patch-history', () => {
         .catch(done)
     })
 
+    it('should not throw "TypeError: Cannot set property _original of null" error with options { new:true } if doc does not exist', (done) => {
+      Post.findOneAndUpdate(
+        { title: 'the_answer_to_life' },
+        { title: '42', comments: 'thanks for all the fish' },
+        { new: true }
+      )
+        .then(() => {
+          done()
+        })
+        .catch(done)
+    })
+
+    it('should work with options { new:true }', (done) => {
+      Post.findOneAndUpdate(
+        { title: 'findOneAndUpdate1' },
+        { title: 'findOneAndUpdate2' },
+        { new: true }
+      )
+        .then(() => done())
+        .catch(done)
+    })
+
     it('should work with options { new:true, rawResult:true }', (done) => {
       Post.findOneAndUpdate(
         { title: 'findOneAndUpdate2' },
@@ -545,7 +567,7 @@ describe('mongoose-patch-history', () => {
         .catch(done)
     })
 
-    it('without changes: doesn\'t add a patch', (done) => {
+    it("without changes: doesn't add a patch", (done) => {
       Post.update(
         { title: 'upsert1' },
         { title: 'upsert1' },


### PR DESCRIPTION
`findOneAndUpdate` with option `{ new: true }` throws an error, if doc does not exist.